### PR TITLE
Add Clarifai's types as new types in airtable: issue #214

### DIFF
--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -72,7 +72,7 @@ class GetDetails extends Component {
         if (apparel && apparel.data.length > 0) {
           const outfit = apparel.data.map((ele) => {
             const name = ele.tag_name;
-            const object = { id: '', itemType: name, name };
+            const object = { itemType: name, name, id: '' };
             return object;
           });
           this.setState({
@@ -114,6 +114,7 @@ class GetDetails extends Component {
       const price = this.state.selected_price.concat(this.state.selected_currency);
       const inputs = {
         type: this.state.selected_itemType,
+        typeId: this.state.selected_itemType.id,
         age: this.state.selected_age,
         price,
         color: this.state.selected_colors,
@@ -129,7 +130,22 @@ class GetDetails extends Component {
         pattern: this.state.selected_patterns,
       };
 
-      if (cookie) {
+      if (inputs.typeId === '') {
+        axios.post('/add-type', { name: inputs.type.name, shortcut: 'New Type' }).then((res) => {
+          const { typeId } = res.data;
+          this.setState({ typeId }, () => {
+            if (cookie) {
+              axios.post('/add-item', inputs).then(({ data }) => {
+                if (data.success) {
+                  history.push({ pathname: '/item-list', logged });
+                }
+              });
+            } else {
+              history.push({ pathname: '/login-form', data: inputs });
+            }
+          });
+        });
+      } else if (cookie) {
         axios.post('/add-item', inputs).then(({ data }) => {
           if (data.success) {
             history.push({ pathname: '/item-list', logged });

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -113,8 +113,7 @@ class GetDetails extends Component {
       const { history } = this.props;
       const price = this.state.selected_price.concat(this.state.selected_currency);
       const inputs = {
-        type: this.state.selected_itemType,
-        typeId: this.state.selected_itemType.id,
+        type: this.state.selected_itemType.id,
         age: this.state.selected_age,
         price,
         color: this.state.selected_colors,
@@ -130,8 +129,8 @@ class GetDetails extends Component {
         pattern: this.state.selected_patterns,
       };
 
-      if (inputs.typeId === '') {
-        axios.post('/add-type', { name: inputs.type.name, shortcut: 'New Type' }).then((res) => {
+      if (inputs.type === '') {
+        axios.post('/add-type', { name: this.state.selected_itemType, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
           this.setState({ typeId }, () => {
             if (cookie) {

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -156,9 +156,7 @@ class GetDetails extends Component {
       this.setState({ [`selected_${name}`]: { id: value1.id, brandName: value1.name } });
     } else if (name === 'itemType') {
       const value1 = JSON.parse(value);
-      this.setState({ [`selected_${name}`]: { id: value1.id, itemType: value1.name, name: value } }, () => {
-        console.log(this.state[`selected_${name}`]);
-      });
+      this.setState({ [`selected_${name}`]: { id: value1.id, itemType: value1.name, name: value } });
     } else if (name === 'colors') {
       const { colors } = this.state;
       const color = colors.filter(x => (x.name === value ? x : null));
@@ -185,9 +183,7 @@ class GetDetails extends Component {
       });
     } else if (name === 'itemType') {
       const value1 = JSON.parse(value);
-      this.setState({ [`selected_${name}`]: { id, itemType: value1.name, name: value }, isOpen: false }, () => {
-        console.log(this.state[`selected_${name}`]);
-      });
+      this.setState({ [`selected_${name}`]: { id, itemType: value1.name, name: value }, isOpen: false });
     } else if (name === 'colors') {
       const { colors } = this.state;
       const color = colors.filter(x => (x.name === value ? x.hex : null));

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -130,7 +130,7 @@ class GetDetails extends Component {
       };
 
       if (inputs.type === '') {
-        axios.post('/add-type', { name: this.state.selected_itemType.name, shortcut: 'New Type' }).then((res) => {
+        axios.post('/add-type', { name: this.state.selected_itemType.itemType, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
           inputs.type = typeId;
         });
@@ -156,7 +156,9 @@ class GetDetails extends Component {
       this.setState({ [`selected_${name}`]: { id: value1.id, brandName: value1.name } });
     } else if (name === 'itemType') {
       const value1 = JSON.parse(value);
-      this.setState({ [`selected_${name}`]: { id: value1.id, itemType: value1.itemType } });
+      this.setState({ [`selected_${name}`]: { id: value1.id, itemType: value1.name, name: value } }, () => {
+        console.log(this.state[`selected_${name}`]);
+      });
     } else if (name === 'colors') {
       const { colors } = this.state;
       const color = colors.filter(x => (x.name === value ? x : null));
@@ -183,7 +185,9 @@ class GetDetails extends Component {
       });
     } else if (name === 'itemType') {
       const value1 = JSON.parse(value);
-      this.setState({ [`selected_${name}`]: { id, itemType: value1.itemType, name: value }, isOpen: false });
+      this.setState({ [`selected_${name}`]: { id, itemType: value1.name, name: value }, isOpen: false }, () => {
+        console.log(this.state[`selected_${name}`]);
+      });
     } else if (name === 'colors') {
       const { colors } = this.state;
       const color = colors.filter(x => (x.name === value ? x.hex : null));

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -132,20 +132,10 @@ class GetDetails extends Component {
       if (inputs.type === '') {
         axios.post('/add-type', { name: this.state.selected_itemType.name, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
-          this.setState({ this.state.selected_itemType.id:`${typeId}` }, () => {
-            console.log(this.state.selected_itemType.id)
-            if (cookie) {
-              axios.post('/add-item', inputs).then(({ data }) => {
-                if (data.success) {
-                  history.push({ pathname: '/item-list', logged });
-                }
-              });
-            } else {
-              history.push({ pathname: '/login-form', data: inputs });
-            }
-          });
+          inputs.type = typeId;
         });
-      } else if (cookie) {
+      }
+      if (cookie) {
         axios.post('/add-item', inputs).then(({ data }) => {
           if (data.success) {
             history.push({ pathname: '/item-list', logged });

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -132,7 +132,7 @@ class GetDetails extends Component {
       if (inputs.type === '') {
         axios.post('/add-type', { name: this.state.selected_itemType.name, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
-          this.setState({ type: typeId }, () => {
+          this.setState({ inputs.type: typeId }, () => {
             if (cookie) {
               axios.post('/add-item', inputs).then(({ data }) => {
                 if (data.success) {

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -132,7 +132,8 @@ class GetDetails extends Component {
       if (inputs.type === '') {
         axios.post('/add-type', { name: this.state.selected_itemType.name, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
-          this.setState({ inputs.type: typeId }, () => {
+          this.setState({ this.state.selected_itemType.id:`${typeId}` }, () => {
+            console.log(this.state.selected_itemType.id)
             if (cookie) {
               axios.post('/add-item', inputs).then(({ data }) => {
                 if (data.success) {

--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -130,9 +130,9 @@ class GetDetails extends Component {
       };
 
       if (inputs.type === '') {
-        axios.post('/add-type', { name: this.state.selected_itemType, shortcut: 'New Type' }).then((res) => {
+        axios.post('/add-type', { name: this.state.selected_itemType.name, shortcut: 'New Type' }).then((res) => {
           const { typeId } = res.data;
-          this.setState({ typeId }, () => {
+          this.setState({ type: typeId }, () => {
             if (cookie) {
               axios.post('/add-item', inputs).then(({ data }) => {
                 if (data.success) {

--- a/server/controllers/addType.js
+++ b/server/controllers/addType.js
@@ -1,0 +1,22 @@
+const Airtable = require('airtable');
+
+const { Airtable_API_KEY } = process.env;
+if (!process.env.Airtable_API_KEY) {
+  throw new Error('Missing Airtable API KEY env var');
+}
+
+const base = new Airtable({ apiKey: Airtable_API_KEY }).base('appAZnpLnWP0wjAc6');
+exports.addType = (req, res) => {
+  const { name, shortcut } = req.body;
+
+  base('Type').create({
+    Shortcut: shortcut,
+    Name: name,
+  }, (err, record) => {
+    if (err) {
+      return res.json({ success: 'false', err });
+    }
+    const typeId = record.getId();
+    return res.json({ success: 'true', typeId });
+  });
+};

--- a/server/router.js
+++ b/server/router.js
@@ -17,6 +17,7 @@ const { getFeedback } = require('./controllers/getFeedback.js');
 const { checkCookie } = require('./controllers/checkCookie.js');
 const { getTypes } = require('./controllers/getTypes.js');
 const { getBrands } = require('./controllers/getBrands.js');
+const { addType } = require('./controllers/addType.js');
 
 
 router.post('/add-to-amazon', uploadPhoto, clarifaiAPIs);
@@ -27,6 +28,7 @@ router.get('/get-types', getTypes);
 
 
 router.post('/add-item', auth, addItem);
+router.post('/add-type', addType);
 router.get('/delete-item/:id', auth, deleteItem);
 router.put('/edit-item/:id', auth, editItem);
 


### PR DESCRIPTION
References issue #214 

What I did in this PR:
**client/src/components/GetDetails/index.js**
- check if item's typeId is empty or not. 
if yes:
 - save it in airtable as a new type and set its newfound Id in the state. 
 - save it to airtable (still not tested).

if not: 
- save item normally as you would do. 

------------------------------------------
**server/router.js**

- added `/POST` route and hander to router. 

-------------------------------------------
**server/controllers/addType.js**

- Handler for the `/POST` endpoint. 
- recieves shortcut and name. 
- adds a new type to airtable where name = itemType and shortcut = "New Type"
- Retrieves the Id from the new added record and sends it to FE.















