### PR TITLE
Filter Clarify's Array to prevent duplicates: issue #114

### DIFF
--- a/client/src/components/GetDetails/index.js
+++ b/client/src/components/GetDetails/index.js
@@ -104,7 +104,9 @@ class GetDetails extends Component {
 
     axios.get('/get-types').then(({ data }) => {
       const type = data.itemType;
-      this.setState({ itemType: [...this.state.itemType, ...type] });
+      const airtableNames = type.map(item => item.name);
+      const filtered = this.state.itemType.filter(item => !airtableNames.includes(item.name));
+      this.setState({ itemType: [...filtered, ...type] });
     });
   }
 


### PR DESCRIPTION
References issue #114 :

What I did in this PR: 
- Define a variable `airtableNames` that has all the values of objects' names as elements in an array.
- Define a variable `filtered` that is checks if an item's name exists in `airtableNames` name or not and filters in accordance to it.